### PR TITLE
Added basic logging

### DIFF
--- a/kvserver/chord.go
+++ b/kvserver/chord.go
@@ -24,7 +24,7 @@ func (c *ChordKV) Get(key string) (string, error) {
 	return key, err
 }
 
-func (c *ChordKV) Set(key string, value string) error {
+func (c *ChordKV) Set(key, value string) error {
 	/*Check for existing key*/
 	if _, ok := c.table[key]; ok {
 		err := errors.New("Key already exists")

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	kvserver "github.com/edudev/chord/kvserver"
 	memcached_wrapper "github.com/edudev/chord/memcached"
 	memcached "github.com/mattrobenolt/go-memcached"
@@ -10,5 +12,10 @@ func main() {
 	backend := kvserver.New()
 	holder := memcached_wrapper.New(&backend)
 	server := memcached.NewServer(":11211", &holder)
+
+	log.SetPrefix("TRACE: ")
+	log.SetFlags(log.Ldate | log.Lmicroseconds | log.Lshortfile)
+	log.Println("log initialised")
+
 	server.ListenAndServe()
 }

--- a/memcached/server.go
+++ b/memcached/server.go
@@ -1,6 +1,8 @@
 package memcached
 
 import (
+	"log"
+
 	memcached "github.com/mattrobenolt/go-memcached"
 )
 
@@ -30,6 +32,7 @@ func (c *MemcachedServer) Get(key string) (response memcached.MemcachedResponse)
 		response = &memcached.ItemResponse{Item: item}
 	} else {
 		response = nil
+		log.Printf("GET FAILED: %s | key received: %s\n", err, key)
 	}
 	return response
 }
@@ -42,6 +45,7 @@ func (c *MemcachedServer) Set(toadd *memcached.Item) (response memcached.Memcach
 		response = &memcached.ClientErrorResponse{
 			Reason: memcached.Error.Error(),
 		}
+		log.Printf("SET FAILED: %s | key-value pair received: {%s : %s}\n", response, toadd.Key, toadd.Value)
 	}
 	return response
 }
@@ -53,6 +57,7 @@ func (c *MemcachedServer) Delete(key string) (response memcached.MemcachedRespon
 		response = &memcached.ClientErrorResponse{
 			Reason: memcached.Error.Error(),
 		}
+		log.Printf("DELETE FAILED: %s | key received: %s\n", err, key)
 	}
 	return response
 }


### PR DESCRIPTION
1. Didn't use `Fatal`, `Fatalf` and `Fatalln` as they call os.Exit(1).
2. Logging for `SET` doesn't work as the memcached-wrapper has it's internal handling. Hopefully you guys can think of a way around. @edudev @dcasenove 

Hopefully the logging text won't bring me hate :)
Although we can try to make it more professional.
